### PR TITLE
salmon does not produce sa.bin files -> pos.bin

### DIFF
--- a/snakefile.py
+++ b/snakefile.py
@@ -114,7 +114,7 @@ targets = {
         'description': "Produce a comprehensive report.  This is the default target.",
         'files':
       [os.path.join(OUTPUT_DIR, 'star_index', "SAindex"),
-            os.path.join(OUTPUT_DIR, 'salmon_index', "sa.bin"),
+            os.path.join(OUTPUT_DIR, 'salmon_index', "pos.bin"),
             os.path.join(MULTIQC_DIR, 'multiqc_report.html')] +
 	  [os.path.join(COUNTS_DIR, "raw_counts", "counts_from_SALMON.transcripts.tsv"),
             os.path.join(COUNTS_DIR, "raw_counts", "counts_from_SALMON.genes.tsv"),
@@ -168,7 +168,7 @@ targets = {
     'salmon_index' : {
         'description': "Create SALMON index file.",
         'files':
-          [os.path.join(OUTPUT_DIR, 'salmon_index', "sa.bin")]
+          [os.path.join(OUTPUT_DIR, 'salmon_index', "pos.bin")]
     },
     'salmon_quant' : {
         'description': "Calculate read counts per transcript using SALMON.",
@@ -322,7 +322,7 @@ rule salmon_index:
   input:
       CDNA_FASTA
   output:
-      salmon_index_file = os.path.join(OUTPUT_DIR, 'salmon_index', "sa.bin")
+      salmon_index_file = os.path.join(OUTPUT_DIR, 'salmon_index', "pos.bin")
   params:
       salmon_index_dir = os.path.join(OUTPUT_DIR, 'salmon_index')
   log: os.path.join(LOG_DIR, 'salmon_index.log')

--- a/tests/test_salmon/test_salmon_index.sh.in
+++ b/tests/test_salmon/test_salmon_index.sh.in
@@ -26,7 +26,7 @@ head -n 2 ${samplesheet} > ${tmp_samplesheet}
 ${builddir}/pigx-rnaseq -s ${tmp_settings} --target salmon_index ${tmp_samplesheet}
 
 rm ${tmp_settings} ${tmp_samplesheet}
-if ! test -f ${testfolder}/salmon_index/sa.bin
+if ! test -f ${testfolder}/salmon_index/pos.bin
 then
   echo "ERROR: failed the SALMON indexing test"
   exit 1


### PR DESCRIPTION
Hello,

I could not find the exact version of salmon you are expecting. The test samples give  a reference to 0.9.0 - but that seems like from quite a while ago. Running salmon 1.3.0 I had a problem with the expected sa.bin files which just do not manifest themselves even though salmon completed successfully. I also failed to locate them in the salmon source tree - gone? I took some creative freedom to change this to pos.bin.

If I am not mistaken and you prefer remain compatible with your current setup, would there then be a reasonable way to have your pipeline run in a salmon-version-agnostic way? Alternatively, you could check the version and adjust the copying/testing behaviour?
```
$ salmon --version
salmon 1.3.0
```
The attached patch helps over here to survive the build testing.

Kind regards,
Steffen