### PR TITLE
helping the user to find STAR setting

### DIFF
--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -96,6 +96,8 @@ tools:
   star_index:
     executable: @STAR@
     args: ""
+    # If STAR gives an error then that error message is likely suggest the parameter to adjust.
+    # args: "--limitGenomeGenerateRAM 31000000000"
   trim-galore:
     executable: @TRIMGALORE@
     args: ""


### PR DESCRIPTION
The STAR error message suggests that a parameter is set somewhere and this comment guides the user who is likely to be grepping for that paramter.

In reaction to https://github.com/BIMSBbioinfo/pigx_rnaseq/issues/83 .

Many thanks!