### PR TITLE
Handle covariates setting in case it is missing - #82

### DIFF
--- a/snakefile.py
+++ b/snakefile.py
@@ -87,6 +87,13 @@ SAMPLE_SHEET_FILE = config['locations']['sample-sheet']
 
 DE_ANALYSIS_LIST = config.get('DEanalyses', {})
 
+# Explicitly check if key 'covariates' is defined, set it to empty string otherwise.
+for analysis in DE_ANALYSIS_LIST.keys():
+    DE_ANALYSIS_LIST[analysis]['covariates'] = (
+        DE_ANALYSIS_LIST[analysis]['covariates'] if 'covariates' in DE_ANALYSIS_LIST[analysis].keys()
+        else ''
+    )
+
 ## Load sample sheet
 with open(SAMPLE_SHEET_FILE, 'r') as fp:
   rows =  [row for row in csv.reader(fp, delimiter=',')]


### PR DESCRIPTION
Fixes #82
snakefile.py: for each DE analysis if 'covariates' is not defined it is set to an empty string ''