### PR TITLE
add snakemake resources + memory requirements per rule

### DIFF
--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -59,6 +59,7 @@ execution:
   submit-to-cluster: no
   jobs: 6
   nice: 19
+  mem_mb: 4000
   cluster:
     missing-file-timeout: 120
     memory: 8G

--- a/pigx-rnaseq.in
+++ b/pigx-rnaseq.in
@@ -323,6 +323,7 @@ command = [
     "--configfile={}".format(args.configfile),
     "--directory={}".format(config['locations']['output-dir']),
     "--jobs={}".format(config['execution']['jobs']),
+    "--resources", "mem_mb={}".format(config['execution']['mem_mb']),
 ]
 
 if config['execution']['submit-to-cluster']:


### PR DESCRIPTION
Let's rebase and merge this.  It's perhaps a little crude, and having a fixed memory hint for each rule independent of file size may be a little inflexible, but this already helps a lot with execution on smaller systems.