### PR TITLE
Avoid runtime error during merge, no headers in table

### DIFF
--- a/scripts/collate_read_counts.R
+++ b/scripts/collate_read_counts.R
@@ -32,21 +32,17 @@ counts <- lapply(count_files, function(f) {
 })
 
 # merge list of data frames
-counts_all <- as.data.frame(Reduce(function(dtf1, dtf2) 
-  merge(dtf1, dtf2, by = "V1", all.x = TRUE),
-       counts))
+labs <- apply(combn(LETTERS,3),2,paste,collapse="")
+counts_all <- as.data.frame(Reduce(function(dtf1, dtf2) {
+    cat("I: ncol(dtf1): ",ncol(dtf1), "  ncol(dtf2): ",ncol(dtf2),"\n")
+    colnames(dtf1)[2:ncol(dtf1)] <- labs[1:ncol(dtf1)-1]
+    # it is sufficient to rename one of the two
+    merge(dtf1, dtf2, by = "V1", all.x = TRUE)
+  }, counts))
+
+
 rownames(counts_all) <- counts_all$V1
 counts_all$V1 <- NULL
 
 # save results to out file
-write.table(counts_all, out_file, quote = FALSE, 
-            sep = '\t')
-
-
-
-
-
-
-
-
-
+write.table(counts_all, out_file, quote = FALSE, col.names=FALSE, sep = '\t')


### PR DESCRIPTION
This is the PR to address what likely is an incompatibility with recent versions of R as found the hard way in Issue #111 .