### PR TITLE
Passing description from settings.yaml to report.

### DIFF
--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -35,6 +35,7 @@ counting:
 #  # string value.
 #
 #  analysis1:
+#    description: "A couple of sentences describing the purpose to perform this particular comparison and the selection of covariates."
 #    # If multiple sample names are provided, they must be separated by comma.
 #    case_sample_groups: "HBR"
 #    control_sample_groups: "UHR"
@@ -46,6 +47,7 @@ counting:
 #    covariates: ""
 #
 #  analysis2:
+#    description: "Every analysis has its disting description which is then shown in the introduction section of the report."
 #    case_sample_groups: "UHR"
 #    control_sample_groups: "HBR"
 #

--- a/scripts/deseqReport.Rmd.in
+++ b/scripts/deseqReport.Rmd.in
@@ -6,6 +6,7 @@ params:
   countDataFile: ''
   colDataFile: ''
   gtfFile: ''
+  description: ''
   caseSampleGroups: ''
   controlSampleGroups: ''
   covariates: ''
@@ -65,6 +66,17 @@ ggplot2::theme_set(ggpubr::theme_pubclean())
 
 # Description
 
+```{r printInputSettings, results='asis'}
+
+if (!is.null(params$description)) {
+   cat("  \n")
+   cat(params$description)
+   cat("  \n")
+   cat("  \n")
+}
+
+```
+
 PiGx RNAseq performs differential expression analysis using _DESeq2_, and produces this report. The report includes tables and figures summarizing similarities and differences between comparison groups as specified in the settings file. In addition to the differential expression analysis, there are plots and statistics for quality control of the experiment in general with an emphasis on the reproducibility of the sequencing results among the biological replicates.
 
 This report was generated with PiGx RNAseq version @VERSION@.
@@ -77,6 +89,7 @@ To reproduce the here presentined findings, consider rerunning the respective co
 countDataFile <- params$countDataFile
 colDataFile <- params$colDataFile
 gtfFile <- params$gtfFile
+description <- params$description
 caseSampleGroups <- params$caseSampleGroups
 controlSampleGroups <- params$controlSampleGroups
 covariates <- params$covariates

--- a/snakefile.py
+++ b/snakefile.py
@@ -523,6 +523,7 @@ rule report1:
     outdir=os.path.join(OUTPUT_DIR, "report", MAPPER),
     reportR=os.path.join(SCRIPTS_DIR, "runDeseqReport.R"),
     reportRmd=os.path.join(SCRIPTS_DIR, "deseqReport.Rmd"),
+    description = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['description'].replace("'",".").replace('"','.'),
     case = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['case_sample_groups'],
     control = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['control_sample_groups'],
     covariates = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['covariates'],
@@ -533,7 +534,7 @@ rule report1:
   resources:
     mem_mb = 4000
   shell:
-    "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}'  --workdir={params.outdir} --organism='{ORGANISM}'  >> {log} 2>&1"
+    "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}'  --workdir={params.outdir} --organism='{ORGANISM}' --description='{description}' >> {log} 2>&1"
 
 rule report2:
   input:
@@ -543,6 +544,7 @@ rule report2:
     outdir=os.path.join(OUTPUT_DIR, "report", 'salmon'),
     reportR=os.path.join(SCRIPTS_DIR, "runDeseqReport.R"),
     reportRmd=os.path.join(SCRIPTS_DIR, "deseqReport.Rmd"),
+    description = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['description'].replace("'",".").replace('"','.'),
     case = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['case_sample_groups'],
     control = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['control_sample_groups'],
     covariates = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['covariates'],
@@ -552,7 +554,7 @@ rule report2:
     os.path.join(OUTPUT_DIR, "report", 'salmon', '{analysis}.salmon.transcripts.deseq.report.html')
   resources:
     mem_mb = 4000
-  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.transcripts' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' >> {log} 2>&1"
+  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.transcripts' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' --description='{description}' >> {log} 2>&1"
 
 rule report3:
   input:
@@ -562,6 +564,7 @@ rule report3:
     outdir=os.path.join(OUTPUT_DIR, "report", "salmon"),
     reportR=os.path.join(SCRIPTS_DIR, "runDeseqReport.R"),
     reportRmd=os.path.join(SCRIPTS_DIR, "deseqReport.Rmd"),
+    description = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['description'].replace("'",".").replace('"','.'),
     case = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['case_sample_groups'],
     control = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['control_sample_groups'],
     covariates = lambda wildcards: DE_ANALYSIS_LIST[wildcards.analysis]['covariates'],
@@ -571,4 +574,4 @@ rule report3:
     os.path.join(OUTPUT_DIR, "report", "salmon", '{analysis}.salmon.genes.deseq.report.html')
   resources:
     mem_mb = 4000
-  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.genes' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' >> {log} 2>&1"
+  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.genes' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' --description='{description}' >> {log} 2>&1"

--- a/snakefile.py
+++ b/snakefile.py
@@ -419,7 +419,7 @@ rule counts_from_SALMON:
       colDataFile = rules.translate_sample_sheet_for_report.output
   output:
       os.path.join(COUNTS_DIR, "raw_counts", "salmon", "counts_from_SALMON.transcripts.tsv"),
-      os.path.join(COUNTS_DIR, "raw_counts", "salmon","counts_from_SALMON.genes.tsv"),
+      os.path.join(COUNTS_DIR, "raw_counts", "salmon", "counts_from_SALMON.genes.tsv"),
       os.path.join(COUNTS_DIR, "normalized", "salmon", "TPM_counts_from_SALMON.transcripts.tsv"),
       os.path.join(COUNTS_DIR, "normalized", "salmon", "TPM_counts_from_SALMON.genes.tsv")
   resources:
@@ -534,7 +534,7 @@ rule report1:
   resources:
     mem_mb = 4000
   shell:
-    "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}'  --workdir={params.outdir} --organism='{ORGANISM}' --description='{description}' >> {log} 2>&1"
+    "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}'  --workdir={params.outdir} --organism='{ORGANISM}' --description='{params.description}' >> {log} 2>&1"
 
 rule report2:
   input:
@@ -554,7 +554,7 @@ rule report2:
     os.path.join(OUTPUT_DIR, "report", 'salmon', '{analysis}.salmon.transcripts.deseq.report.html')
   resources:
     mem_mb = 4000
-  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.transcripts' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' --description='{description}' >> {log} 2>&1"
+  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.transcripts' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' --description='{params.description}' >> {log} 2>&1"
 
 rule report3:
   input:
@@ -574,4 +574,4 @@ rule report3:
     os.path.join(OUTPUT_DIR, "report", "salmon", '{analysis}.salmon.genes.deseq.report.html')
   resources:
     mem_mb = 4000
-  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.genes' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' --description='{description}' >> {log} 2>&1"
+  shell: "{RSCRIPT_EXEC} {params.reportR} --logo={params.logo} --prefix='{wildcards.analysis}.salmon.genes' --reportFile={params.reportRmd} --countDataFile={input.counts} --colDataFile={input.coldata} --gtfFile={GTF_FILE} --caseSampleGroups='{params.case}' --controlSampleGroups='{params.control}' --covariates='{params.covariates}' --workdir={params.outdir} --organism='{ORGANISM}' --description='{params.description}' >> {log} 2>&1"

--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -14,6 +14,7 @@ mapping:
 DEanalyses:
   #names of analyses can be anything but they have to be unique for each combination of case control group comparisons.
   analysis1:
+    description: "This analysis is part of the pigx-rnaseq build-time tests."
     #if multiple sample names is provided, they must be separated by comma
     case_sample_groups: "HBR"
     control_sample_groups: "UHR"


### PR DESCRIPTION
Your reports are the first encounter for our collaborators with their data. Our experimental setup is a bit complicated and so I came up with several analyses. These all have their own name but I wished for a description in the report that explains what the respective comparison is about.

I have not run this locally, yet (snakemake is still busy) but thought I seek this early opportunity to ask if you like this idea, so I will improve on it. 

Since the reports are invoked both on salmon and hisat2, I think it would be nice to see explained in the introduction what the particular value of each quantification is. Maybe I would even want to go as far as to provide an automatically generated methods section at the end of the report.

Would that be something you would lke to see as a PR (maybe an evolution of this one)?