### PR TITLE
scripts/collate: header is always needed, not 'auto'

### DIFF
--- a/scripts/collate_read_counts.R
+++ b/scripts/collate_read_counts.R
@@ -28,12 +28,12 @@ count_files <- dir(input_dir, pattern = ".read_counts.csv$", full.names = TRUE)
 
 # get read counts for each sample into a list
 counts <- lapply(count_files, function(f) {
-  data.table::fread(f)
+  data.table::fread(f,header=TRUE)
 })
 
 # merge list of data frames
 counts_all <- as.data.frame(Reduce(function(dtf1, dtf2) 
-  merge(dtf1, dtf2, by = "V1", all.x = TRUE),
+  merge(dtf1, dtf2, by="V1", all.x=TRUE, all.y=TRUE),
        counts))
 rownames(counts_all) <- counts_all$V1
 counts_all$V1 <- NULL


### PR DESCRIPTION
This is a continuation of https://github.com/BIMSBbioinfo/pigx_rnaseq/pull/113 .

For me the pipeline broke because the sample names were numeric, which the fread function then did not recognize as a column name. Since the pipeline only works if column headers are present, this implies header=TRUE.

A second concern is the all.x=TRUE but all.y=FALSE (the default). This would imply that transcripts cannot be added with later files that have not been identified in the first files. This may not be a thing because of how hisat2 etc work, but then do not set all.x either.

